### PR TITLE
Do not start sftp by default

### DIFF
--- a/lib/esshd/server.ex
+++ b/lib/esshd/server.ex
@@ -50,8 +50,10 @@ defmodule Sshd.Server do
     preferred_algorithms =
       Application.fetch_env!(:esshd, :preferred_algorithms)
         || :ssh.default_algorithms()
+    subsystems = Application.fetch_env!(:esshd, :subsystems)
 
     case :ssh.daemon port, shell: &on_shell/2,
+                           subsystems: subsystems,
                            system_dir: priv_dir,
                            user_dir: priv_dir,
                            user_passwords: [],

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Sshd.Mixfile do
         flags: [:unmatched_returns, :error_handling, :race_conditions, :no_opaque]
      ],
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test, "coveralls.json": :test],
+     preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test, "coveralls.json": :test],
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Sshd.Mixfile do
        password_authenticator: "Sshd.PasswordAuthenticator.Default",
        access_list: "Sshd.AccessList.Default",
        public_key_authenticator: "Sshd.PublicKeyAuthenticator.Default",
+       subsystems: [],
      ]]
   end
 


### PR DESCRIPTION
I was a little surprised to find out that starting the sshd daemon *also* started the sftp daemon, which does not go through a custom handler but just drops one straight to the remote filesystem. As this is undocumented behaviour (one has to read through the erlang apidocs to notice..), it seems dangerous to ship it as is. Those who want sftp can add that back in easily enough, but the rest of us won't end up accidentally exposing our server fs ;)