### PR TITLE
replaced deprecated Logger.warn with Logger.warning

### DIFF
--- a/lib/esshd/example_shell_handler.ex
+++ b/lib/esshd/example_shell_handler.ex
@@ -14,9 +14,7 @@ defmodule Sshd.ShellHandler.Example do
   def on_connect(username, ip, port, method) do
     Logger.debug(fn ->
       """
-      Incoming SSH shell #{inspect(self())} requested for #{username} from #{inspect(ip)}:#{
-        inspect(port)
-      } using #{inspect(method)}
+      Incoming SSH shell #{inspect(self())} requested for #{username} from #{inspect(ip)}:#{inspect(port)} using #{inspect(method)}
       """
     end)
   end
@@ -53,7 +51,7 @@ defmodule Sshd.ShellHandler.Example do
         loop(%{state | counter: state.counter + 1})
 
       {:input, ^input, msg} ->
-        :ok = Logger.warn("received unknown message: #{inspect(msg)}")
+        :ok = Logger.warning("received unknown message: #{inspect(msg)}")
         loop(%{state | counter: state.counter + 1})
     end
   end

--- a/lib/esshd/server.ex
+++ b/lib/esshd/server.ex
@@ -113,9 +113,7 @@ defmodule Sshd.Server do
   def on_password(username, password, peer_address, state) do
     :ok =
       Logger.debug(fn ->
-        "Checking #{inspect(username)} with password #{inspect(password)} from #{
-          inspect(peer_address)
-        }"
+        "Checking #{inspect(username)} with password #{inspect(password)} from #{inspect(peer_address)}"
       end)
 
     # credo:disable-for-next-line
@@ -159,7 +157,7 @@ defmodule Sshd.Server do
       # drop the connection AFTER N password attempts
       if state.attempts >= 2 do
         :ok =
-          Logger.warn(
+          Logger.warning(
             "ATTEMPT TO ACCESS FAILED for #{inspect(username)} from #{inspect(peer_address)}"
           )
 
@@ -180,10 +178,8 @@ defmodule Sshd.Server do
   @doc false
   @spec on_shell_unauthorized(String.t(), peer_address, term) :: any
   def on_shell_unauthorized(username, {ip, port}, reason) do
-    Logger.warn("""
-    Authentication failure for #{inspect(username)} from #{inspect(ip)}:#{inspect(port)}: #{
-      inspect(reason)
-    }
+    Logger.warning("""
+    Authentication failure for #{inspect(username)} from #{inspect(ip)}:#{inspect(port)}: #{inspect(reason)}
     """)
   end
 

--- a/lib/esshd/shell_handler.ex
+++ b/lib/esshd/shell_handler.ex
@@ -82,7 +82,7 @@ defmodule Sshd.ShellHandler do
           :ok = on_shell(username, ssh_publickey, ip_address, port_number)
         rescue
           _ ->
-            _ = Logger.warn("Exception caught")
+            _ = Logger.warning("Exception caught")
             :ok
         end
 


### PR DESCRIPTION
`Logger.warn` was deprecated in Elixir 1.15.0: I replaced it with `Logger.warning`